### PR TITLE
feat: make blocsync the default server

### DIFF
--- a/blocsync/lib/src/api_client.dart
+++ b/blocsync/lib/src/api_client.dart
@@ -6,19 +6,19 @@ import 'package:web_socket_client/web_socket_client.dart';
 class ApiClient {
   ApiClient({
     required this.apiKey,
-    required Uri baseUrl,
+    String baseUrl = 'https://api.blocsync.dev',
     http.Client? client,
     this.authenticationToken,
   })  : client = client ?? http.Client(),
-        host = baseUrl.host,
-        port = baseUrl.port,
-        secure = baseUrl.scheme.endsWith('s');
+        host = Uri.parse(baseUrl).host,
+        port = Uri.parse(baseUrl).port,
+        secure = Uri.parse(baseUrl).scheme.endsWith('s');
 
   final String apiKey;
   final http.Client client;
 
   final String host;
-  final int port;
+  final int? port;
   final bool secure;
 
   String? authenticationToken;

--- a/cspell.json
+++ b/cspell.json
@@ -1,9 +1,17 @@
 {
   "version": "0.2",
-  "ignorePaths": [],
+  "ignorePaths": [
+    "**/example/**",
+    "**/node_modules/**",
+    "**.svg",
+    "**/dist/**",
+  ],
   "dictionaryDefinitions": [],
   "dictionaries": [],
   "words": [
+    "FLUSHALL",
+    "Twichel",
+    "pubspec",
     "blocsync",
     "endtemplate",
     "Hmac",


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This pull request updates the `ApiClient` class in `blocsync/lib/src/api_client.dart` to improve usability and simplify the initialization process. The most important change is the replacement of the `baseUrl` parameter with a default string value, along with adjustments to how `host`, `port`, and `secure` are derived.

### Updates to `ApiClient` initialization:

* The `baseUrl` parameter now defaults to `'https://api.blocsync.dev'` instead of requiring a `Uri` object during initialization. This simplifies the instantiation of `ApiClient` for common use cases.
* `host`, `port`, and `secure` are now derived by parsing the `baseUrl` string using `Uri.parse(baseUrl)`. This ensures consistent handling of the base URL and avoids requiring the caller to pass a `Uri`.
* The `port` field type has been updated from `int` to `int?` to accommodate cases where the port might not be explicitly specified in the URL.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
