### PR TITLE
feat: make websockets work on web

### DIFF
--- a/blocsync/lib/src/api_client.dart
+++ b/blocsync/lib/src/api_client.dart
@@ -116,16 +116,24 @@ class ApiClient {
       authenticationToken = null;
     }
 
-    return WebSocket(_makeUrl('/live/$storageToken', scheme: 'ws'), headers: {
-      'x-api-key': apiKey,
-      if (authenticationToken != null)
-        'x-authentication-token': authenticationToken
-    });
-  }
+    final ticketResponse = await client.post(
+      _makeUrl('/live/$storageToken'),
+      headers: {
+        'x-api-key': apiKey,
+        if (authenticationToken != null)
+          'x-authentication-token': authenticationToken,
+      },
+    );
 
-  WebSocket connect(String storageToken) {
-    final uri = _makeUrl('/subscribe/$storageToken', scheme: 'ws');
+    if (ticketResponse.statusCode != 200) {
+      throw Exception('Failed to get live ticket');
+    }
 
-    return WebSocket(uri, headers: {'x-api-key': apiKey});
+    final sessionId = jsonDecode(ticketResponse.body)['sessionId'];
+    if (sessionId is! String) {
+      throw Exception('Failed to get live session id');
+    }
+
+    return WebSocket(_makeUrl('/live/subscribe/$sessionId', scheme: 'ws'));
   }
 }

--- a/blocsync_server/lib/src/state_storage/hive_state_storage.dart
+++ b/blocsync_server/lib/src/state_storage/hive_state_storage.dart
@@ -32,7 +32,11 @@ class HiveStateStorage implements StateStorage {
   }
 
   @override
-  Future<void> put(String key, Map<String, dynamic> value) async {
+  Future<void> put(
+    String key,
+    Map<String, dynamic> value, {
+    Duration? ttl,
+  }) async {
     await _box.put(key, value);
   }
 }

--- a/blocsync_server/lib/src/state_storage/redis_state_storage.dart
+++ b/blocsync_server/lib/src/state_storage/redis_state_storage.dart
@@ -45,7 +45,16 @@ class RedisStateStorage implements StateStorage {
   }
 
   @override
-  Future<void> put(String key, Map<String, dynamic> value) async {
-    await _command.send_object(['SET', key, jsonEncode(value)]);
+  Future<void> put(
+    String key,
+    Map<String, dynamic> value, {
+    Duration? ttl,
+  }) async {
+    if (ttl != null) {
+      await _command
+          .send_object(['SET', key, jsonEncode(value), 'EX', ttl.inSeconds]);
+    } else {
+      await _command.send_object(['SET', key, jsonEncode(value)]);
+    }
   }
 }

--- a/blocsync_server/lib/src/state_storage/state_storage.dart
+++ b/blocsync_server/lib/src/state_storage/state_storage.dart
@@ -6,7 +6,7 @@ abstract class StateStorage {
   const StateStorage();
 
   /// Put a value in the storage.
-  Future<void> put(String key, Map<String, dynamic> value);
+  Future<void> put(String key, Map<String, dynamic> value, {Duration? ttl});
 
   /// Get a value from the storage.
   Future<Map<String, dynamic>?> get(String key);

--- a/blocsync_server/pubspec.yaml
+++ b/blocsync_server/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^1.2.0
   pointycastle: ^4.0.0
   redis: ^4.0.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   mocktail: ^1.0.3

--- a/blocsync_server/routes/_middleware.dart
+++ b/blocsync_server/routes/_middleware.dart
@@ -47,7 +47,7 @@ Handler middleware(Handler handler) {
   var newHandler = handler
       .use(corsMiddleware())
       .use(requestLogger())
-      // .use(apiKeyMiddleware())
+      .use(apiKeyMiddleware())
       .use(provider<StateStorage>((_) => storage));
   if (authenticationEnabled) {
     newHandler = newHandler.use(jwtMiddleware());

--- a/blocsync_server/routes/live/subscribe/[sessionId].dart
+++ b/blocsync_server/routes/live/subscribe/[sessionId].dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:blocsync_server/blocsync_server.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_web_socket/dart_frog_web_socket.dart';
+
+final Map<String, Set<WebSocketChannel>> _channels = {};
+Future<Response> onRequest(RequestContext context, String sessionId) async {
+  final storage = context.read<StateStorage>();
+  final session = await storage.get('live_session:$sessionId');
+  if (session == null) {
+    return Response(statusCode: HttpStatus.notFound);
+  }
+  final userId = session['userId'];
+  final ipAddress = session['ip_address'];
+  final id = session['id'];
+
+  if (userId is! String? || id is! String) {
+    return Response(statusCode: HttpStatus.notFound);
+  }
+
+  if (ipAddress != context.request.headers['x-forwarded-for']) {
+    return Response(statusCode: HttpStatus.forbidden);
+  }
+
+  await storage.delete('live_session:$sessionId');
+
+  final handler = webSocketHandler((channel, protocol) {
+    _channels.putIfAbsent(id, () => {}).add(channel);
+    channel.stream.listen((message) async {
+      if (message is! String) {
+        return;
+      }
+      final decoded = Map<String, dynamic>.from(jsonDecode(message) as Map);
+      final event = decoded['event'] as Map<String, dynamic>?;
+      final state = decoded['state'] as Map<String, dynamic>?;
+      if (event != null) {
+        for (final otherChannel in _channels[id]!) {
+          if (otherChannel == channel) {
+            continue;
+          }
+          otherChannel.sink.add(message);
+        }
+      }
+      if (state != null) {
+        if (userId == null) {
+          await storage.put(id, state);
+        } else {
+          await storage.put('$userId:$id', state);
+        }
+      }
+    });
+  });
+  return handler(context);
+}

--- a/blocsync_server/start.sh
+++ b/blocsync_server/start.sh
@@ -1,0 +1,6 @@
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+
+dart_frog dev

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
 
   BlocSyncConfig.apiClient = ApiClient(
     baseUrl: 'http://localhost:8080',
-    apiKey: 'test_api_key',
+    apiKey: 'k_28668e1cc8998e7c824c0b55e5eef9d0',
   );
 
   runApp(const MainApp());


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This pull request introduces a new secure live session mechanism for WebSocket connections and refactors how state is stored and managed in both Redis and Hive backends. The main changes include replacing the direct WebSocket connection with a ticket/session-based flow, implementing session validation and expiry, and supporting optional TTL for state storage. These updates improve security, scalability, and flexibility for live state synchronization.

**Live session and WebSocket connection flow:**

* Added a ticket/session-based mechanism for live WebSocket connections: clients must first POST to `/live/:id` to receive a `sessionId`, then connect via WebSocket to `/live/subscribe/:sessionId`, which validates session info and IP address before allowing connection. (`blocsync/lib/src/api_client.dart`, `blocsync_server/routes/live/[id].dart`, `blocsync_server/routes/live/subscribe/[sessionId].dart`) ([blocsync/lib/src/api_client.dartL119-R137](diffhunk://#diff-51f8a1566ecf76a1f8154fbe67bbb0ef160b8e9d0af9e9cc3538c92acad434edL119-R137), [blocsync_server/routes/live/[id].dartL1-R31](diffhunk://#diff-98969cd24336eee26610e29e4b91a1b5cd34ccf4ce23c5802cae6447e3c85fedL1-R31), [blocsync_server/routes/live/subscribe/[sessionId].dartR1-R56](diffhunk://#diff-c79ae798eff70cd65830c038d72d7ef9f136c9959a2c1548b1736091054c2210R1-R56))
* Session records are stored with a 2-second TTL to prevent replay attacks and ensure short-lived authorization. (`blocsync_server/routes/live/[id].dart`, `blocsync_server/lib/src/state_storage/redis_state_storage.dart`, `blocsync_server/lib/src/state_storage/hive_state_storage.dart`, `blocsync_server/lib/src/state_storage/state_storage.dart`) ([blocsync_server/routes/live/[id].dartL1-R31](diffhunk://#diff-98969cd24336eee26610e29e4b91a1b5cd34ccf4ce23c5802cae6447e3c85fedL1-R31), [[1]](diffhunk://#diff-c1438adffb9bf9211ca9626fb92e5fad05276a1c0e85655f0f8766d74c246386L48-R60) [[2]](diffhunk://#diff-9d13a965a8e52b02d9a80e9428ea1b3c0fe626074a6299ea1ecaf39736a70f4bL35-R39) [[3]](diffhunk://#diff-95b879211dbcbf56157132ca57d09b449a562b8a661184743e130928c550064eL9-R9)

**State storage improvements:**

* Updated `StateStorage` interface and implementations (`RedisStateStorage`, `HiveStateStorage`) to support an optional TTL for stored values, enabling automatic expiration for temporary session data. (`blocsync_server/lib/src/state_storage/state_storage.dart`, `blocsync_server/lib/src/state_storage/redis_state_storage.dart`, `blocsync_server/lib/src/state_storage/hive_state_storage.dart`) [[1]](diffhunk://#diff-95b879211dbcbf56157132ca57d09b449a562b8a661184743e130928c550064eL9-R9) [[2]](diffhunk://#diff-c1438adffb9bf9211ca9626fb92e5fad05276a1c0e85655f0f8766d74c246386L48-R60) [[3]](diffhunk://#diff-9d13a965a8e52b02d9a80e9428ea1b3c0fe626074a6299ea1ecaf39736a70f4bL35-R39)

**Security and middleware:**

* Reactivated the API key middleware for all requests to improve security. (`blocsync_server/routes/_middleware.dart`)

**Dependency and environment updates:**

* Added the `uuid` package for session ID generation and improved environment variable loading in the server startup script. (`blocsync_server/pubspec.yaml`, `blocsync_server/start.sh`) [[1]](diffhunk://#diff-aa7f0986e4b34cde532ef245b7f773f161d3166c32364eed1908c190c4d3f214R17) [[2]](diffhunk://#diff-edccec6e49c1cfbb07c9e2f94a8043afcb2d5133838c06d0cb3e5f11aec87916R1-R6)

**Other:**

* Updated example client to use a new API key for live testing. (`example/lib/main.dart`)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
